### PR TITLE
[DB] Add workout indexes for published and id lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@
 1. Copy `.env.example` to `.env`.
 2. Run `npm install`.
 3. Run `npm run db:migrate` to apply local Prisma migrations.
+4. Verify query plans for V1 filters:
+   - `EXPLAIN QUERY PLAN SELECT * FROM "Workout" WHERE "isPublished" = 1`
+   - `EXPLAIN QUERY PLAN SELECT * FROM "Workout" WHERE "id" = 'workout_1'`

--- a/prisma/migrations/20260207133000_add_workout_indexes/migration.sql
+++ b/prisma/migrations/20260207133000_add_workout_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "idx_workouts_is_published" ON "Workout"("isPublished");
+
+-- CreateIndex
+CREATE INDEX "idx_workouts_id_lookup" ON "Workout"("id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,4 +14,7 @@ model Workout {
   equipment      String
   data           String
   isPublished    Boolean @default(false)
+
+  @@index([isPublished], map: "idx_workouts_is_published")
+  @@index([id], map: "idx_workouts_id_lookup")
 }

--- a/tests/db/workout-indexes.test.ts
+++ b/tests/db/workout-indexes.test.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { PrismaClient } from '@prisma/client';
+import { afterAll, describe, expect, it } from 'vitest';
+
+const executeSqlScript = async (prisma: PrismaClient, scriptPath: string) => {
+  const sql = readFileSync(scriptPath, 'utf8');
+
+  for (const statement of sql.split(';')) {
+    const trimmed = statement.trim();
+    if (!trimmed) continue;
+    await prisma.$executeRawUnsafe(`${trimmed};`);
+  }
+};
+
+const dbPath = join('/tmp', `wod-now-index-${randomUUID()}.db`);
+const prisma = new PrismaClient({
+  datasources: {
+    db: {
+      url: `file:${dbPath}`
+    }
+  }
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe('Workout indexes', () => {
+  it('includes index migration for isPublished and id', () => {
+    const migrationSql = readFileSync(
+      'prisma/migrations/20260207133000_add_workout_indexes/migration.sql',
+      'utf8'
+    );
+
+    expect(migrationSql).toContain('idx_workouts_is_published');
+    expect(migrationSql).toContain('idx_workouts_id_lookup');
+  });
+
+  it('uses indexes in query plans for published and id filters', async () => {
+    await executeSqlScript(
+      prisma,
+      'prisma/migrations/20260207131500_init_workout/migration.sql'
+    );
+    await executeSqlScript(
+      prisma,
+      'prisma/migrations/20260207133000_add_workout_indexes/migration.sql'
+    );
+
+    const publishedPlan = (await prisma.$queryRawUnsafe(
+      'EXPLAIN QUERY PLAN SELECT * FROM "Workout" WHERE "isPublished" = 1'
+    )) as Array<{ detail: string }>;
+
+    const idPlan = (await prisma.$queryRawUnsafe(
+      'EXPLAIN QUERY PLAN SELECT * FROM "Workout" WHERE "id" = ?1',
+      'workout_1'
+    )) as Array<{ detail: string }>;
+
+    expect(publishedPlan.some((row) => row.detail.includes('idx_workouts_is_published'))).toBe(true);
+    expect(idPlan.some((row) => row.detail.includes('INDEX'))).toBe(true);
+  });
+});

--- a/tests/db/workout-schema.test.ts
+++ b/tests/db/workout-schema.test.ts
@@ -12,5 +12,7 @@ describe('Workout Prisma model', () => {
     expect(schema).toContain('equipment      String');
     expect(schema).toContain('data           String');
     expect(schema).toContain('isPublished    Boolean @default(false)');
+    expect(schema).toContain('@@index([isPublished], map: "idx_workouts_is_published")');
+    expect(schema).toContain('@@index([id], map: "idx_workouts_id_lookup")');
   });
 });


### PR DESCRIPTION
## Summary
- add Prisma indexes for isPublished and id lookup
- add migration with explicit index creation statements
- add query plan tests covering common filters (isPublished and id)
- document local query-plan verification commands in README

Closes #2

## Validation
- npm test