### PR TITLE
[Recovery][DB] Issue #3 Prisma singleton to main

### DIFF
--- a/src/app/api/workouts/route.ts
+++ b/src/app/api/workouts/route.ts
@@ -1,0 +1,12 @@
+import { db } from '../../../lib/db.js';
+
+type WorkoutsScaffoldResponse = {
+  count: number;
+};
+
+export async function GET(): Promise<Response> {
+  const count = await db.workout.count({});
+  const body: WorkoutsScaffoldResponse = { count };
+
+  return Response.json(body, { status: 200 });
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client';
+
+type GlobalWithPrisma = typeof globalThis & {
+  prisma?: PrismaClient;
+};
+
+const globalForPrisma = globalThis as GlobalWithPrisma;
+
+export const db = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = db;
+}

--- a/tests/api/workouts-route-scaffold.test.ts
+++ b/tests/api/workouts-route-scaffold.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { count } = vi.hoisted(() => ({
+  count: vi.fn().mockResolvedValue(3)
+}));
+
+vi.mock('../../src/lib/db.js', () => ({
+  db: {
+    workout: {
+      count
+    }
+  }
+}));
+
+import { GET } from '../../src/app/api/workouts/route.js';
+
+describe('GET /api/workouts scaffold', () => {
+  it('uses db singleton and returns count payload', async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ count: 3 });
+    expect(count).toHaveBeenCalledWith({});
+  });
+});

--- a/tests/db/db-singleton.test.ts
+++ b/tests/db/db-singleton.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const getDbModule = async () => import('../../src/lib/db.js');
+
+const clearGlobalPrisma = () => {
+  const globalForPrisma = globalThis as typeof globalThis & { prisma?: unknown };
+  delete globalForPrisma.prisma;
+};
+
+afterEach(() => {
+  clearGlobalPrisma();
+  vi.resetModules();
+  delete process.env.NODE_ENV;
+});
+
+describe('Prisma client singleton', () => {
+  it('reuses a single client across reloads in development', async () => {
+    process.env.NODE_ENV = 'development';
+
+    const firstModule = await getDbModule();
+    const firstDb = firstModule.db;
+
+    vi.resetModules();
+
+    const secondModule = await getDbModule();
+
+    expect(secondModule.db).toBe(firstDb);
+  });
+
+  it('does not persist client globally in production', async () => {
+    process.env.NODE_ENV = 'production';
+
+    const firstModule = await getDbModule();
+    const firstDb = firstModule.db;
+
+    vi.resetModules();
+
+    const secondModule = await getDbModule();
+
+    expect(secondModule.db).not.toBe(firstDb);
+  });
+});


### PR DESCRIPTION
## Summary
- cherry-pick only issue #3 implementation onto main
- add src/lib/db.ts Prisma singleton (dev/prod safe)
- consume singleton in scaffold workouts route
- include singleton and route tests

Related to #3

## Validation
- npm test