### PR TITLE
[Recovery][API] Issue #6 random endpoint stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,19 @@
 1. Copy `.env.example` to `.env`.
 2. Run `npm install`.
 3. Run `npm run db:migrate` to apply local Prisma migrations.
+
+## API contracts
+### `GET /api/workouts/random`
+- Query params:
+  - `timeCapMax` (optional positive integer, seconds)
+  - `equipment` (optional CSV list)
+  - `exclude` (optional CSV list of workout ids)
+- Responses:
+  - `200` with one published workout:
+    - `id: string`
+    - `title: string`
+    - `timeCapSeconds: number`
+    - `equipment: string[]`
+    - `data: unknown`
+  - `404` when no workout matches filters
+  - `400` when `timeCapMax` is invalid

--- a/src/app/api/workouts/contracts.ts
+++ b/src/app/api/workouts/contracts.ts
@@ -12,3 +12,48 @@ export const workoutApiSelect = Prisma.validator<Prisma.WorkoutSelect>()({
 export type WorkoutApiRecord = Prisma.WorkoutGetPayload<{
   select: typeof workoutApiSelect;
 }>;
+
+export type WorkoutResponse = {
+  id: string;
+  title: string;
+  timeCapSeconds: number;
+  equipment: string[];
+  data: unknown;
+};
+
+const parseEquipment = (equipment: string): string[] | null => {
+  try {
+    const parsed = JSON.parse(equipment) as unknown;
+    if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === 'string')) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+const parseData = (data: string): unknown | null => {
+  try {
+    return JSON.parse(data) as unknown;
+  } catch {
+    return null;
+  }
+};
+
+export const toWorkoutResponse = (workout: WorkoutApiRecord): WorkoutResponse | null => {
+  const equipment = parseEquipment(workout.equipment);
+  const data = parseData(workout.data);
+
+  if (!equipment || data === null) {
+    return null;
+  }
+
+  return {
+    id: workout.id,
+    title: workout.title,
+    timeCapSeconds: workout.timeCapSeconds,
+    equipment,
+    data
+  };
+};

--- a/src/app/api/workouts/random/route.ts
+++ b/src/app/api/workouts/random/route.ts
@@ -1,0 +1,96 @@
+import { Prisma } from '@prisma/client';
+
+import { db } from '../../../../lib/db.js';
+import {
+  toWorkoutResponse,
+  workoutApiSelect,
+  type WorkoutResponse
+} from '../contracts.js';
+
+type RandomWorkoutQuery = {
+  timeCapMax?: number;
+  equipment: string[];
+  exclude: string[];
+};
+
+type ErrorResponse = {
+  error: string;
+};
+
+const parseCsvValues = (searchParams: URLSearchParams, key: string): string[] => {
+  return searchParams
+    .getAll(key)
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+};
+
+const parseQuery = (request: Request): RandomWorkoutQuery | ErrorResponse => {
+  const url = new URL(request.url);
+  const rawTimeCapMax = url.searchParams.get('timeCapMax');
+
+  if (rawTimeCapMax === null) {
+    return {
+      equipment: parseCsvValues(url.searchParams, 'equipment'),
+      exclude: parseCsvValues(url.searchParams, 'exclude')
+    };
+  }
+
+  const timeCapMax = Number(rawTimeCapMax);
+  if (!Number.isInteger(timeCapMax) || timeCapMax <= 0) {
+    return { error: 'timeCapMax must be a positive integer' };
+  }
+
+  return {
+    timeCapMax,
+    equipment: parseCsvValues(url.searchParams, 'equipment'),
+    exclude: parseCsvValues(url.searchParams, 'exclude')
+  };
+};
+
+const matchesEquipment = (workoutEquipment: string[], requiredEquipment: string[]): boolean => {
+  if (requiredEquipment.length === 0) {
+    return true;
+  }
+
+  const workoutSet = new Set(workoutEquipment.map((item) => item.toLowerCase()));
+  return requiredEquipment.every((requiredItem) =>
+    workoutSet.has(requiredItem.toLowerCase())
+  );
+};
+
+const pickRandomWorkout = (workouts: WorkoutResponse[]): WorkoutResponse => {
+  const index = Math.floor(Math.random() * workouts.length);
+  return workouts[index];
+};
+
+export async function GET(request: Request): Promise<Response> {
+  const query = parseQuery(request);
+  if ('error' in query) {
+    return Response.json(query, { status: 400 });
+  }
+
+  const where: Prisma.WorkoutWhereInput = {
+    isPublished: true,
+    ...(query.timeCapMax !== undefined
+      ? { timeCapSeconds: { lte: query.timeCapMax } }
+      : {}),
+    ...(query.exclude.length > 0 ? { id: { notIn: query.exclude } } : {})
+  };
+
+  const workouts = await db.workout.findMany({
+    where,
+    select: workoutApiSelect
+  });
+
+  const candidates = workouts
+    .map(toWorkoutResponse)
+    .filter((workout): workout is WorkoutResponse => workout !== null)
+    .filter((workout) => matchesEquipment(workout.equipment, query.equipment));
+
+  if (candidates.length === 0) {
+    return new Response(null, { status: 404 });
+  }
+
+  return Response.json(pickRandomWorkout(candidates), { status: 200 });
+}

--- a/tests/api/workouts-random-route.test.ts
+++ b/tests/api/workouts-random-route.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { findMany } = vi.hoisted(() => ({
+  findMany: vi.fn()
+}));
+
+vi.mock('../../src/lib/db.js', () => ({
+  db: {
+    workout: {
+      findMany
+    }
+  }
+}));
+
+import { GET } from '../../src/app/api/workouts/random/route.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  findMany.mockReset();
+});
+
+describe('GET /api/workouts/random', () => {
+  it('returns 404 when no candidate workout exists', async () => {
+    findMany.mockResolvedValue([]);
+
+    const response = await GET(new Request('https://example.com/api/workouts/random'));
+
+    expect(response.status).toBe(404);
+  });
+
+  it('applies timeCapMax and exclude filters to db query', async () => {
+    findMany.mockResolvedValue([
+      {
+        id: 'w2',
+        title: 'Helen',
+        timeCapSeconds: 540,
+        equipment: JSON.stringify(['barbell']),
+        data: JSON.stringify({ reps: 1 }),
+        isPublished: true
+      }
+    ]);
+
+    const response = await GET(
+      new Request('https://example.com/api/workouts/random?timeCapMax=600&exclude=w1,w3')
+    );
+
+    expect(response.status).toBe(200);
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        isPublished: true,
+        timeCapSeconds: { lte: 600 },
+        id: { notIn: ['w1', 'w3'] }
+      },
+      select: {
+        id: true,
+        title: true,
+        timeCapSeconds: true,
+        equipment: true,
+        data: true,
+        isPublished: true
+      }
+    });
+  });
+
+  it('applies equipment subset filtering and random selection', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.9);
+
+    findMany.mockResolvedValue([
+      {
+        id: 'w1',
+        title: 'No Pull-Up Bar',
+        timeCapSeconds: 500,
+        equipment: JSON.stringify(['barbell']),
+        data: JSON.stringify({}),
+        isPublished: true
+      },
+      {
+        id: 'w2',
+        title: 'Fran',
+        timeCapSeconds: 480,
+        equipment: JSON.stringify(['barbell', 'pull-up bar']),
+        data: JSON.stringify({ rounds: [21, 15, 9] }),
+        isPublished: true
+      },
+      {
+        id: 'w3',
+        title: 'DT',
+        timeCapSeconds: 720,
+        equipment: JSON.stringify(['barbell', 'pull-up bar']),
+        data: JSON.stringify({ rounds: [12, 9, 6] }),
+        isPublished: true
+      }
+    ]);
+
+    const response = await GET(
+      new Request('https://example.com/api/workouts/random?equipment=barbell,pull-up%20bar')
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      id: 'w3',
+      title: 'DT',
+      timeCapSeconds: 720,
+      equipment: ['barbell', 'pull-up bar'],
+      data: { rounds: [12, 9, 6] }
+    });
+  });
+
+  it('returns 400 for invalid timeCapMax', async () => {
+    const response = await GET(
+      new Request('https://example.com/api/workouts/random?timeCapMax=abc')
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'timeCapMax must be a positive integer'
+    });
+  });
+});

--- a/tests/db/workout-contracts.test.ts
+++ b/tests/db/workout-contracts.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { workoutApiSelect } from '../../src/app/api/workouts/contracts.js';
+import {
+  toWorkoutResponse,
+  workoutApiSelect
+} from '../../src/app/api/workouts/contracts.js';
 
 describe('Workout API contracts', () => {
   it('select shape exposes required API fields', () => {
@@ -11,6 +14,25 @@ describe('Workout API contracts', () => {
       equipment: true,
       data: true,
       isPublished: true
+    });
+  });
+
+  it('maps persisted JSON strings to typed API response payload', () => {
+    const mapped = toWorkoutResponse({
+      id: 'w1',
+      title: 'Fran',
+      timeCapSeconds: 480,
+      equipment: JSON.stringify(['barbell', 'pull-up bar']),
+      data: JSON.stringify({ rounds: 21 }),
+      isPublished: true
+    });
+
+    expect(mapped).toEqual({
+      id: 'w1',
+      title: 'Fran',
+      timeCapSeconds: 480,
+      equipment: ['barbell', 'pull-up bar'],
+      data: { rounds: 21 }
     });
   });
 });


### PR DESCRIPTION
## Summary
- cherry-pick only issue #6 implementation onto clean issue #3 branch
- implement GET /api/workouts/random with timeCapMax, equipment, and exclude filters
- return one published workout or 404
- add explicit typed response mapping and route tests

Related to #6

## Validation
- npm test