### PR TITLE
[Recovery][API] Issue #7 by-id endpoint stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,15 @@
     - `data: unknown`
   - `404` when no workout matches filters
   - `400` when `timeCapMax` is invalid
+
+### `GET /api/workouts/[id]`
+- Path param:
+  - `id` workout id
+- Responses:
+  - `200` with published workout payload:
+    - `id: string`
+    - `title: string`
+    - `timeCapSeconds: number`
+    - `equipment: string[]`
+    - `data: unknown`
+  - `404` for missing or unpublished id

--- a/src/app/api/workouts/[id]/route.ts
+++ b/src/app/api/workouts/[id]/route.ts
@@ -1,0 +1,36 @@
+import { db } from '../../../../lib/db.js';
+
+import {
+  toWorkoutResponse,
+  workoutApiSelect
+} from '../contracts.js';
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+export async function GET(
+  _request: Request,
+  context: RouteContext
+): Promise<Response> {
+  const workout = await db.workout.findFirst({
+    where: {
+      id: context.params.id,
+      isPublished: true
+    },
+    select: workoutApiSelect
+  });
+
+  if (!workout) {
+    return new Response(null, { status: 404 });
+  }
+
+  const response = toWorkoutResponse(workout);
+  if (response === null) {
+    return Response.json({ error: 'Invalid workout payload' }, { status: 500 });
+  }
+
+  return Response.json(response, { status: 200 });
+}

--- a/tests/api/workout-by-id-route.test.ts
+++ b/tests/api/workout-by-id-route.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { findFirst } = vi.hoisted(() => ({
+  findFirst: vi.fn()
+}));
+
+vi.mock('../../src/lib/db.js', () => ({
+  db: {
+    workout: {
+      findFirst
+    }
+  }
+}));
+
+import { GET } from '../../src/app/api/workouts/[id]/route.js';
+
+afterEach(() => {
+  findFirst.mockReset();
+});
+
+describe('GET /api/workouts/[id]', () => {
+  it('returns published workout by id', async () => {
+    findFirst.mockResolvedValue({
+      id: 'w1',
+      title: 'Fran',
+      timeCapSeconds: 480,
+      equipment: JSON.stringify(['barbell', 'pull-up bar']),
+      data: JSON.stringify({ rounds: [21, 15, 9] }),
+      isPublished: true
+    });
+
+    const response = await GET(new Request('https://example.com/api/workouts/w1'), {
+      params: { id: 'w1' }
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      id: 'w1',
+      title: 'Fran',
+      timeCapSeconds: 480,
+      equipment: ['barbell', 'pull-up bar'],
+      data: { rounds: [21, 15, 9] }
+    });
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'w1',
+        isPublished: true
+      },
+      select: {
+        id: true,
+        title: true,
+        timeCapSeconds: true,
+        equipment: true,
+        data: true,
+        isPublished: true
+      }
+    });
+  });
+
+  it('returns 404 for missing or unpublished workout', async () => {
+    findFirst.mockResolvedValue(null);
+
+    const response = await GET(new Request('https://example.com/api/workouts/missing'), {
+      params: { id: 'missing' }
+    });
+
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- cherry-pick only issue #7 implementation onto clean issue #6 branch
- implement GET /api/workouts/[id] for published workouts
- return 404 for missing/unpublished ids
- add route tests and response contract docs update

Related to #7

## Validation
- npm test