### PR TITLE
feat: implement workout Zod schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "wod-now",
       "version": "0.1.0",
       "dependencies": {
-        "@prisma/client": "^6.2.1"
+        "@prisma/client": "^6.2.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -1896,6 +1897,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "vitest": "^2.1.8"
   },
   "dependencies": {
-    "@prisma/client": "^6.2.1"
+    "@prisma/client": "^6.2.1",
+    "zod": "^4.3.6"
   }
 }

--- a/src/lib/workout-schema.ts
+++ b/src/lib/workout-schema.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+const nonEmptyString = z.string().trim().min(1, 'Must not be empty');
+
+export const workoutMovementSchema = z
+  .object({
+    name: nonEmptyString,
+    reps: z.number().int().positive().optional(),
+    calories: z.number().int().positive().optional(),
+    distanceMeters: z.number().int().positive().optional(),
+    load: nonEmptyString.optional(),
+    notes: nonEmptyString.optional()
+  })
+  .strict()
+  .refine(
+    (movement) =>
+      movement.reps !== undefined ||
+      movement.calories !== undefined ||
+      movement.distanceMeters !== undefined ||
+      movement.load !== undefined,
+    {
+      message:
+        'Movement must define at least one of reps, calories, distanceMeters, or load',
+      path: ['reps']
+    }
+  );
+
+export const workoutBlockSchema = z
+  .object({
+    name: nonEmptyString,
+    duration: z.union([z.number().int().positive(), z.literal('remaining')]).optional(),
+    movements: z.array(workoutMovementSchema).min(1, 'Block must include at least one movement'),
+    notes: nonEmptyString.optional()
+  })
+  .strict();
+
+export const workoutSchema = z
+  .object({
+    id: nonEmptyString,
+    title: nonEmptyString,
+    timeCapSeconds: z.number().int().positive().optional(),
+    equipment: z.array(nonEmptyString).default([]),
+    blocks: z.array(workoutBlockSchema).min(1, 'Workout must include at least one block'),
+    notes: z
+      .object({
+        coach: nonEmptyString.optional(),
+        scaling: nonEmptyString.optional()
+      })
+      .strict()
+      .optional(),
+    isPublished: z.boolean().default(false)
+  })
+  .strict();
+
+export type WorkoutInput = z.input<typeof workoutSchema>;
+export type Workout = z.output<typeof workoutSchema>;
+
+export const parseWorkout = (payload: unknown): Workout => {
+  return workoutSchema.parse(payload);
+};
+
+export const safeParseWorkout = (payload: unknown) => {
+  return workoutSchema.safeParse(payload);
+};

--- a/tests/lib/workout-schema.test.ts
+++ b/tests/lib/workout-schema.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseWorkout,
+  safeParseWorkout,
+  workoutBlockSchema,
+  workoutMovementSchema,
+  workoutSchema
+} from '../../src/lib/workout-schema.js';
+
+const validWorkout = {
+  id: 'wod-001',
+  title: 'Fran',
+  timeCapSeconds: 480,
+  equipment: ['barbell', 'pull-up bar'],
+  blocks: [
+    {
+      name: 'Main Piece',
+      duration: 480,
+      movements: [
+        {
+          name: 'Thruster',
+          reps: 45,
+          load: '95/65 lb'
+        },
+        {
+          name: 'Pull-up',
+          reps: 45
+        }
+      ]
+    }
+  ],
+  notes: {
+    scaling: 'Use lighter barbell load as needed'
+  },
+  isPublished: true
+};
+
+describe('workout movement schema', () => {
+  it('rejects movements without a measurable prescription', () => {
+    const result = workoutMovementSchema.safeParse({
+      name: 'Run'
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('workout block schema', () => {
+  it('accepts remaining duration blocks', () => {
+    const result = workoutBlockSchema.safeParse({
+      name: 'Cash Out',
+      duration: 'remaining',
+      movements: [
+        {
+          name: 'Burpee',
+          reps: 50
+        }
+      ]
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('workout schema', () => {
+  it('parses a valid workout payload', () => {
+    expect(parseWorkout(validWorkout)).toEqual(validWorkout);
+  });
+
+  it('supports optional fields: timeCapSeconds and notes.scaling', () => {
+    const withoutOptionalFields = {
+      id: 'wod-002',
+      title: 'Untimed Skill Work',
+      equipment: [],
+      blocks: [
+        {
+          name: 'EMOM',
+          movements: [
+            {
+              name: 'Strict Pull-up',
+              reps: 3
+            }
+          ]
+        }
+      ],
+      notes: {
+        scaling: 'Use banded pull-ups'
+      }
+    };
+
+    const parsed = parseWorkout(withoutOptionalFields);
+
+    expect(parsed.timeCapSeconds).toBeUndefined();
+    expect(parsed.notes?.scaling).toBe('Use banded pull-ups');
+    expect(parsed.isPublished).toBe(false);
+  });
+
+  it('rejects invalid top-level payloads', () => {
+    const result = safeParseWorkout({
+      id: '',
+      title: 'Broken Payload',
+      blocks: []
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('is strict about unknown fields', () => {
+    const result = workoutSchema.safeParse({
+      ...validWorkout,
+      unexpected: true
+    });
+
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add strict workout validation schema with top-level, block, and movement validation
- export parse helpers for ingestion usage
- add unit coverage for valid/invalid payloads and optional fields

## Testing
- npm test

Closes #4