### PR TITLE
feat: add cross-field validation for remaining duration

### DIFF
--- a/src/lib/workout-schema.ts
+++ b/src/lib/workout-schema.ts
@@ -50,7 +50,21 @@ export const workoutSchema = z
       .optional(),
     isPublished: z.boolean().default(false)
   })
-  .strict();
+  .strict()
+  .superRefine((workout, ctx) => {
+    const hasRemainingBlock = workout.blocks.some(
+      (block) => block.duration === 'remaining'
+    );
+
+    if (hasRemainingBlock && workout.timeCapSeconds === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['timeCapSeconds'],
+        message:
+          'timeCapSeconds is required when any block uses duration=\"remaining\"'
+      });
+    }
+  });
 
 export type WorkoutInput = z.input<typeof workoutSchema>;
 export type Workout = z.output<typeof workoutSchema>;

--- a/tests/lib/workout-schema.test.ts
+++ b/tests/lib/workout-schema.test.ts
@@ -96,6 +96,40 @@ describe('workout schema', () => {
     expect(parsed.isPublished).toBe(false);
   });
 
+  it('requires timeCapSeconds when any block duration is remaining', () => {
+    const result = safeParseWorkout({
+      id: 'wod-003',
+      title: 'For Time',
+      equipment: ['dumbbell'],
+      blocks: [
+        {
+          name: 'Main Piece',
+          duration: 'remaining',
+          movements: [
+            {
+              name: 'DB Snatch',
+              reps: 30
+            }
+          ]
+        }
+      ],
+      isPublished: false
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ['timeCapSeconds'],
+            message:
+              'timeCapSeconds is required when any block uses duration="remaining"'
+          })
+        ])
+      );
+    }
+  });
+
   it('rejects invalid top-level payloads', () => {
     const result = safeParseWorkout({
       id: '',


### PR DESCRIPTION
## Summary
- add schema-layer cross-field rule requiring timeCapSeconds when any block has duration=remaining
- return actionable validation issue on timeCapSeconds path
- add passing/failing unit tests for this rule

## Testing
- npm test

Closes #5