### PR TITLE
feat: add admin workouts ingestion endpoint

### DIFF
--- a/src/app/api/admin/workouts/route.ts
+++ b/src/app/api/admin/workouts/route.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod';
+
+import { db } from '../../../../lib/db.js';
+import { safeParseWorkout } from '../../../../lib/workout-schema.js';
+
+type ApiError = {
+  error: {
+    code: string;
+    message: string;
+    details?: Array<{
+      path: string;
+      message: string;
+    }>;
+  };
+};
+
+type AdminWorkoutResponse = {
+  id: string;
+  isPublished: boolean;
+};
+
+const unauthorized = (): Response => {
+  const body: ApiError = {
+    error: {
+      code: 'UNAUTHORIZED',
+      message: 'Missing or invalid admin API key'
+    }
+  };
+
+  return Response.json(body, { status: 401 });
+};
+
+const badRequest = (message: string, details?: ApiError['error']['details']): Response => {
+  const body: ApiError = {
+    error: {
+      code: 'BAD_REQUEST',
+      message,
+      ...(details && details.length > 0 ? { details } : {})
+    }
+  };
+
+  return Response.json(body, { status: 400 });
+};
+
+const toPath = (path: ReadonlyArray<PropertyKey>): string => {
+  if (path.length === 0) {
+    return '$';
+  }
+
+  return path
+    .map((segment) => {
+      if (typeof segment === 'number') {
+        return `[${segment}]`;
+      }
+      if (typeof segment === 'symbol') {
+        return segment.toString();
+      }
+      return segment;
+    })
+    .join('.');
+};
+
+const toValidationDetails = (issues: z.ZodIssue[]): ApiError['error']['details'] => {
+  return issues.map((issue) => ({
+    path: toPath(issue.path),
+    message: issue.message
+  }));
+};
+
+const parseAdminAuth = (request: Request): boolean => {
+  const configuredKey = process.env.ADMIN_API_KEY;
+  const requestKey = request.headers.get('x-admin-key');
+
+  if (!configuredKey || !requestKey) {
+    return false;
+  }
+
+  return requestKey === configuredKey;
+};
+
+export async function POST(request: Request): Promise<Response> {
+  if (!parseAdminAuth(request)) {
+    return unauthorized();
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return badRequest('Request body must be valid JSON');
+  }
+
+  const parsedWorkout = safeParseWorkout(payload);
+  if (!parsedWorkout.success) {
+    return badRequest('Workout payload validation failed', toValidationDetails(parsedWorkout.error.issues));
+  }
+
+  const workout = parsedWorkout.data;
+  const persisted = await db.workout.upsert({
+    where: { id: workout.id },
+    create: {
+      id: workout.id,
+      title: workout.title,
+      timeCapSeconds: workout.timeCapSeconds ?? 0,
+      equipment: JSON.stringify(workout.equipment),
+      data: JSON.stringify({
+        blocks: workout.blocks,
+        ...(workout.notes ? { notes: workout.notes } : {})
+      }),
+      isPublished: workout.isPublished
+    },
+    update: {
+      title: workout.title,
+      timeCapSeconds: workout.timeCapSeconds ?? 0,
+      equipment: JSON.stringify(workout.equipment),
+      data: JSON.stringify({
+        blocks: workout.blocks,
+        ...(workout.notes ? { notes: workout.notes } : {})
+      }),
+      isPublished: workout.isPublished
+    },
+    select: {
+      id: true,
+      isPublished: true
+    }
+  });
+
+  const response: AdminWorkoutResponse = {
+    id: persisted.id,
+    isPublished: persisted.isPublished
+  };
+
+  return Response.json(response, { status: 200 });
+}

--- a/tests/api/admin-workouts-route.test.ts
+++ b/tests/api/admin-workouts-route.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { upsert } = vi.hoisted(() => ({
+  upsert: vi.fn()
+}));
+
+vi.mock('../../src/lib/db.js', () => ({
+  db: {
+    workout: {
+      upsert
+    }
+  }
+}));
+
+import { POST } from '../../src/app/api/admin/workouts/route.js';
+
+describe('POST /api/admin/workouts', () => {
+  const originalAdminKey = process.env.ADMIN_API_KEY;
+
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = 'secret-key';
+  });
+
+  afterEach(() => {
+    if (originalAdminKey === undefined) {
+      delete process.env.ADMIN_API_KEY;
+    } else {
+      process.env.ADMIN_API_KEY = originalAdminKey;
+    }
+
+    upsert.mockReset();
+  });
+
+  it('returns 401 when x-admin-key is missing', async () => {
+    const response = await POST(
+      new Request('https://example.com/api/admin/workouts', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({})
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Missing or invalid admin API key'
+      }
+    });
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when x-admin-key is invalid', async () => {
+    const response = await POST(
+      new Request('https://example.com/api/admin/workouts', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-admin-key': 'wrong-key'
+        },
+        body: JSON.stringify({})
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Missing or invalid admin API key'
+      }
+    });
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid payload with actionable validation details', async () => {
+    const response = await POST(
+      new Request('https://example.com/api/admin/workouts', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-admin-key': 'secret-key'
+        },
+        body: JSON.stringify({
+          id: 'w1',
+          title: 'Missing blocks',
+          equipment: [],
+          blocks: []
+        })
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        code: 'BAD_REQUEST',
+        message: 'Workout payload validation failed',
+        details: [
+          {
+            path: 'blocks',
+            message: 'Workout must include at least one block'
+          }
+        ]
+      }
+    });
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('upserts workout and returns publish state', async () => {
+    upsert.mockResolvedValue({
+      id: 'wod-001',
+      isPublished: true
+    });
+
+    const response = await POST(
+      new Request('https://example.com/api/admin/workouts', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-admin-key': 'secret-key'
+        },
+        body: JSON.stringify({
+          id: 'wod-001',
+          title: 'Fran',
+          timeCapSeconds: 480,
+          equipment: ['barbell', 'pull-up bar'],
+          blocks: [
+            {
+              name: 'Main Piece',
+              duration: 480,
+              movements: [
+                {
+                  name: 'Thruster',
+                  reps: 45,
+                  load: '95/65 lb'
+                }
+              ]
+            }
+          ],
+          notes: {
+            scaling: 'Use lighter load'
+          },
+          isPublished: true
+        })
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      id: 'wod-001',
+      isPublished: true
+    });
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: { id: 'wod-001' },
+      create: {
+        id: 'wod-001',
+        title: 'Fran',
+        timeCapSeconds: 480,
+        equipment: JSON.stringify(['barbell', 'pull-up bar']),
+        data: JSON.stringify({
+          blocks: [
+            {
+              name: 'Main Piece',
+              duration: 480,
+              movements: [
+                {
+                  name: 'Thruster',
+                  reps: 45,
+                  load: '95/65 lb'
+                }
+              ]
+            }
+          ],
+          notes: {
+            scaling: 'Use lighter load'
+          }
+        }),
+        isPublished: true
+      },
+      update: {
+        title: 'Fran',
+        timeCapSeconds: 480,
+        equipment: JSON.stringify(['barbell', 'pull-up bar']),
+        data: JSON.stringify({
+          blocks: [
+            {
+              name: 'Main Piece',
+              duration: 480,
+              movements: [
+                {
+                  name: 'Thruster',
+                  reps: 45,
+                  load: '95/65 lb'
+                }
+              ]
+            }
+          ],
+          notes: {
+            scaling: 'Use lighter load'
+          }
+        }),
+        isPublished: true
+      },
+      select: {
+        id: true,
+        isPublished: true
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement POST /api/admin/workouts
- enforce strict x-admin-key authentication (401 on missing/invalid key)
- validate payload with workout schema and return actionable 400 errors
- upsert workout record and persist publish state
- add integration tests for happy and failure paths

## Testing
- npm test

Closes #8