### PR TITLE
[Release] Add V1 env docs, deploy checklist, and smoke tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 DATABASE_URL="file:./dev.db"
+ADMIN_API_KEY="replace-with-long-random-secret"

--- a/README.md
+++ b/README.md
@@ -1,14 +1,52 @@
 # wod-now
 
-## Local database setup
+## Environment Variables
+Create a `.env` file in the repo root.
+
+- `DATABASE_URL`:
+  - Local default: `file:./dev.db`
+  - Used by Prisma for API reads/writes and seeding.
+- `ADMIN_API_KEY`:
+  - Required by `POST /api/admin/workouts` via `x-admin-key` header.
+  - Example: `ADMIN_API_KEY="replace-with-long-random-secret"`
+
+Reference example:
+
+```env
+DATABASE_URL="file:./dev.db"
+ADMIN_API_KEY="replace-with-long-random-secret"
+```
+
+## Local Database Setup
 1. Copy `.env.example` to `.env`.
 2. Run `npm install`.
-3. Run `npm run db:migrate` to apply local Prisma migrations.
-4. Verify query plans for V1 filters:
+3. Run `npm run db:push` to sync the local Prisma schema.
+4. Run `npm run seed` to validate and upsert curated workouts.
+5. Verify query plans for V1 filters:
    - `EXPLAIN QUERY PLAN SELECT * FROM "Workout" WHERE "isPublished" = 1`
    - `EXPLAIN QUERY PLAN SELECT * FROM "Workout" WHERE "id" = 'workout_1'`
 
-## API contracts
+## V1 Smoke Tests
+Run these after deployment (or locally with `npm run dev`).
+
+1. Random workout flow:
+   - Open `/` and click `Get random workout`.
+   - Confirm a workout card is rendered with `id`, `title`, `timeCapSeconds`, `equipment`, and `data`.
+   - API spot check: `curl -sS "http://127.0.0.1:3000/api/workouts/random"` returns `200`.
+2. By-id page flow:
+   - From a random response, copy `id` (example: `v1-fran`).
+   - Open `/wod/<id>` and confirm workout details render.
+   - API spot check: `curl -sS "http://127.0.0.1:3000/api/workouts/<id>"` returns `200`.
+3. Admin ingestion flow:
+   - Send an authenticated upsert request:
+     - `curl -i -X POST "http://127.0.0.1:3000/api/admin/workouts" -H "content-type: application/json" -H "x-admin-key: <ADMIN_API_KEY>" --data '{"id":"smoke-admin-001","title":"Smoke Admin","timeCapSeconds":300,"equipment":["barbell"],"blocks":[{"name":"Main","duration":300,"movements":[{"name":"Thruster","reps":30}]}],"isPublished":true}'`
+   - Confirm unauthorized requests without `x-admin-key` return `401`.
+   - Confirm valid payloads return `200` with `id` and `isPublished`.
+
+## Deployment Checklist
+Use the V1 release runbook in `/Users/dmaia/development/repos/wod-now/docs/v1-deploy-checklist.md`.
+
+## API Contracts
 ### Error response contract (all endpoints)
 - Non-`200` responses return JSON:
   - `error.code: string`

--- a/docs/v1-deploy-checklist.md
+++ b/docs/v1-deploy-checklist.md
@@ -1,0 +1,33 @@
+# V1 Deployment Checklist
+
+## 1. Pre-deploy
+- Confirm CI is green for the release commit (`npm test`).
+- Confirm `.env` includes:
+  - `DATABASE_URL`
+  - `ADMIN_API_KEY`
+- Confirm seed dataset exists at `/Users/dmaia/development/repos/wod-now/prisma/seed/workouts.json`.
+
+## 2. Database and seed
+- Run `npm run db:push`.
+- Run `npm run seed`.
+- Validate inserted records:
+  - `node -e "const {PrismaClient}=require('@prisma/client');(async()=>{const p=new PrismaClient();console.log('total='+await p.workout.count()+' published='+await p.workout.count({where:{isPublished:true}}));await p.$disconnect();})();"`
+- Expected result: `total>=50` and `published==total`.
+
+## 3. Runtime checks
+- Start app: `npm run dev` (or production runtime).
+- Random flow check:
+  - `curl -i "http://127.0.0.1:3000/api/workouts/random"` returns `200`.
+- By-id flow check:
+  - Extract an id from random response and request `GET /api/workouts/<id>`; expect `200`.
+  - Open `/wod/<id>` in browser; details render without error state.
+- Admin ingestion checks:
+  - Unauthorized: missing `x-admin-key` returns `401`.
+  - Authorized valid payload returns `200` with `id` and `isPublished`.
+
+## 4. Post-deploy monitoring
+- Check app logs for `500` responses on:
+  - `/api/workouts/random`
+  - `/api/workouts/[id]`
+  - `/api/admin/workouts`
+- If failure is data-related, re-run `npm run seed` and re-test smoke steps.


### PR DESCRIPTION
## Summary
- document required environment variables (DATABASE_URL and ADMIN_API_KEY) in README and .env.example
- add V1 deployment checklist at docs/v1-deploy-checklist.md
- add explicit smoke test steps for random flow, by-id page flow, and admin ingestion flow

## Validation
- npm test
- npm run db:push && npm run seed

Closes #15