### PR TITLE
Phase 1: fix Next.js route typing build blocker

### DIFF
--- a/src/app/api/workouts/[id]/route.ts
+++ b/src/app/api/workouts/[id]/route.ts
@@ -7,23 +7,19 @@ import {
 } from '../contracts.js';
 
 type RouteContext = {
-  params:
-    | {
-        id: string;
-      }
-    | Promise<{
+  params: Promise<{
     id: string;
-      }>;
+  }>;
 };
 
 export async function GET(
   _request: Request,
-  context: RouteContext
+  { params }: RouteContext
 ): Promise<Response> {
-  const params = await Promise.resolve(context.params);
+  const { id } = await params;
   const workout = await db.workout.findFirst({
     where: {
-      id: params.id,
+      id,
       isPublished: true
     },
     select: workoutApiSelect

--- a/tests/api/workout-by-id-route.test.ts
+++ b/tests/api/workout-by-id-route.test.ts
@@ -30,7 +30,7 @@ describe('GET /api/workouts/[id]', () => {
     });
 
     const response = await GET(new Request('https://example.com/api/workouts/w1'), {
-      params: { id: 'w1' }
+      params: Promise.resolve({ id: 'w1' })
     });
 
     expect(response.status).toBe(200);
@@ -61,7 +61,7 @@ describe('GET /api/workouts/[id]', () => {
     findFirst.mockResolvedValue(null);
 
     const response = await GET(new Request('https://example.com/api/workouts/missing'), {
-      params: { id: 'missing' }
+      params: Promise.resolve({ id: 'missing' })
     });
 
     expect(response.status).toBe(404);


### PR DESCRIPTION
## Summary
- update src/app/api/workouts/[id]/route.ts handler context to Next.js 15-compatible params typing
- preserve route behavior while switching to promised params
- update by-id API route tests to match new handler signature

## Validation
- npm run build
- npm run typecheck
- npm test