### PR TITLE
Runtime DB: use pg + IAM signer instead of Prisma URL init

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 Create a `.env` file in the repo root.
 
 - `DATABASE_URL`:
-  - Optional when using `PG*` + IAM token flow.
-  - If set, used directly by Prisma for API reads/writes and seeding.
+  - Optional for URL-based Prisma workflows (migrations/seed scripts).
+  - Runtime API handlers do not require it when using IAM `PG*` configuration.
 - `DIRECT_URL`:
-  - Optional when using `PG*` + IAM token flow.
-  - If set, used for migrations (`prisma migrate deploy`).
+  - Optional for Prisma migration workflows (`prisma migrate deploy`).
 - `PGHOST`, `PGPORT`, `PGUSER`, `PGDATABASE`, `PGSSLMODE`, `AWS_REGION`:
-  - Used by IAM wrapper scripts to generate short-lived Postgres auth tokens and build Prisma URLs.
+  - Used by IAM wrapper scripts to generate short-lived Postgres auth tokens and build Prisma URLs for migrations/seed.
+  - Also used by runtime API handlers (`pg` + IAM signer) to query Aurora without static DB URLs.
   - This aligns with the Vercel Aurora tutorial flow after `vercel env pull`.
 - `PGPASSWORD`:
   - Optional override. If set, wrapper scripts use it instead of generating IAM tokens.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
+        "@types/pg": "^8.16.0",
         "playwright": "^1.58.2",
         "prisma": "^6.2.1",
         "tsx": "^4.21.0",
@@ -2937,6 +2938,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.5",
+    "@types/pg": "^8.16.0",
     "playwright": "^1.58.2",
     "prisma": "^6.2.1",
     "tsx": "^4.21.0",

--- a/src/app/api/workouts/contracts.ts
+++ b/src/app/api/workouts/contracts.ts
@@ -1,17 +1,15 @@
-import { Prisma } from '@prisma/client';
+import type { WorkoutRecord } from '../../../lib/db.js';
 
-export const workoutApiSelect = Prisma.validator<Prisma.WorkoutSelect>()({
+export const workoutApiSelect = {
   id: true,
   title: true,
   timeCapSeconds: true,
   equipment: true,
   data: true,
   isPublished: true
-});
+} as const;
 
-export type WorkoutApiRecord = Prisma.WorkoutGetPayload<{
-  select: typeof workoutApiSelect;
-}>;
+export type WorkoutApiRecord = WorkoutRecord;
 
 export type WorkoutResponse = {
   id: string;

--- a/src/app/api/workouts/random/route.ts
+++ b/src/app/api/workouts/random/route.ts
@@ -1,5 +1,3 @@
-import { Prisma } from '@prisma/client';
-
 import { jsonError } from '../../../../lib/api-error.js';
 import { db } from '../../../../lib/db.js';
 import {
@@ -67,7 +65,7 @@ export async function GET(request: Request): Promise<Response> {
     return jsonError(400, 'BAD_REQUEST', query.error);
   }
 
-  const where: Prisma.WorkoutWhereInput = {
+  const where = {
     isPublished: true,
     ...(query.timeCapMax !== undefined
       ? { timeCapSeconds: { lte: query.timeCapMax } }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,13 +1,271 @@
-import { PrismaClient } from '@prisma/client';
+import { attachDatabasePool } from '@vercel/functions';
+import { awsCredentialsProvider } from '@vercel/functions/oidc';
+import { Signer } from '@aws-sdk/rds-signer';
+import { Pool } from 'pg';
 
-type GlobalWithPrisma = typeof globalThis & {
-  prisma?: PrismaClient;
+export type WorkoutRecord = {
+  id: string;
+  title: string;
+  timeCapSeconds: number;
+  equipment: string;
+  data: string;
+  isPublished: boolean;
 };
 
-const globalForPrisma = globalThis as GlobalWithPrisma;
+type WorkoutSelect = Partial<Record<keyof WorkoutRecord, boolean>>;
 
-export const db = globalForPrisma.prisma ?? new PrismaClient();
+type WorkoutWhereInput = {
+  id?: string | { notIn: string[] };
+  isPublished?: boolean;
+  timeCapSeconds?: { lte: number };
+};
+
+type WorkoutFindManyArgs = {
+  where?: WorkoutWhereInput;
+  select?: WorkoutSelect;
+};
+
+type WorkoutFindFirstArgs = {
+  where?: WorkoutWhereInput;
+  select?: WorkoutSelect;
+};
+
+type WorkoutCountArgs = {
+  where?: WorkoutWhereInput;
+};
+
+type WorkoutUpsertArgs = {
+  where: { id: string };
+  create: WorkoutRecord;
+  update: Partial<WorkoutRecord>;
+  select?: WorkoutSelect;
+};
+
+type DbClient = {
+  workout: {
+    findMany: (args: WorkoutFindManyArgs) => Promise<WorkoutRecord[]>;
+    findFirst: (args: WorkoutFindFirstArgs) => Promise<WorkoutRecord | null>;
+    count: (args: WorkoutCountArgs) => Promise<number>;
+    upsert: (args: WorkoutUpsertArgs) => Promise<WorkoutRecord>;
+  };
+};
+
+type GlobalWithDb = typeof globalThis & {
+  db?: DbClient;
+  dbPool?: Pool;
+};
+
+const globalForDb = globalThis as GlobalWithDb;
+
+const workoutColumns: ReadonlyArray<keyof WorkoutRecord> = [
+  'id',
+  'title',
+  'timeCapSeconds',
+  'equipment',
+  'data',
+  'isPublished'
+];
+
+const requiredEnv = (key: string): string => {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Missing required env var: ${key}`);
+  }
+  return value;
+};
+
+const resolveSelect = (select?: WorkoutSelect): ReadonlyArray<keyof WorkoutRecord> => {
+  if (!select) {
+    return workoutColumns;
+  }
+
+  const selected = workoutColumns.filter((column) => select[column]);
+  if (selected.length === 0) {
+    return ['id'];
+  }
+
+  return selected;
+};
+
+const columnSql = (columns: ReadonlyArray<keyof WorkoutRecord>): string =>
+  columns.map((column) => `"${column}"`).join(', ');
+
+const buildWhereSql = (
+  where: WorkoutWhereInput | undefined,
+  startAt = 1
+): { clause: string; values: unknown[] } => {
+  if (!where) {
+    return { clause: '', values: [] };
+  }
+
+  const clauses: string[] = [];
+  const values: unknown[] = [];
+  let index = startAt;
+
+  if (typeof where.id === 'string') {
+    clauses.push(`"id" = $${index}`);
+    values.push(where.id);
+    index += 1;
+  } else if (where.id?.notIn && where.id.notIn.length > 0) {
+    clauses.push(`NOT ("id" = ANY($${index}::text[]))`);
+    values.push(where.id.notIn);
+    index += 1;
+  }
+
+  if (where.isPublished !== undefined) {
+    clauses.push(`"isPublished" = $${index}`);
+    values.push(where.isPublished);
+    index += 1;
+  }
+
+  if (where.timeCapSeconds?.lte !== undefined) {
+    clauses.push(`"timeCapSeconds" <= $${index}`);
+    values.push(where.timeCapSeconds.lte);
+    index += 1;
+  }
+
+  if (clauses.length === 0) {
+    return { clause: '', values };
+  }
+
+  return {
+    clause: `WHERE ${clauses.join(' AND ')}`,
+    values
+  };
+};
+
+const createIamPasswordResolver = () => {
+  const region = requiredEnv('AWS_REGION');
+  const signer = new Signer({
+    hostname: requiredEnv('PGHOST'),
+    port: Number(requiredEnv('PGPORT')),
+    username: requiredEnv('PGUSER'),
+    region,
+    ...(process.env.AWS_ROLE_ARN
+      ? {
+          credentials: awsCredentialsProvider({
+            roleArn: process.env.AWS_ROLE_ARN,
+            clientConfig: { region }
+          })
+        }
+      : {})
+  });
+
+  let cachedToken: { value: string; expiresAtMs: number } | null = null;
+
+  return async (): Promise<string> => {
+    const now = Date.now();
+    if (cachedToken && now < cachedToken.expiresAtMs) {
+      return cachedToken.value;
+    }
+
+    const value = await signer.getAuthToken();
+    cachedToken = {
+      value,
+      expiresAtMs: now + 14 * 60 * 1000
+    };
+
+    return value;
+  };
+};
+
+const createPool = (): Pool => {
+  const connectionString = process.env.DATABASE_URL;
+  const sslMode = process.env.PGSSLMODE ?? 'require';
+  const ssl =
+    sslMode === 'disable'
+      ? false
+      : {
+          rejectUnauthorized: false
+        };
+
+  const pool = connectionString
+    ? new Pool({ connectionString, ssl })
+    : new Pool({
+        host: requiredEnv('PGHOST'),
+        port: Number(requiredEnv('PGPORT')),
+        user: requiredEnv('PGUSER'),
+        database: requiredEnv('PGDATABASE'),
+        password: process.env.PGPASSWORD ?? createIamPasswordResolver(),
+        ssl,
+        max: Number(process.env.PGPOOL_MAX ?? 20)
+      });
+
+  attachDatabasePool(pool);
+  return pool;
+};
+
+const getPool = (): Pool => {
+  if (process.env.NODE_ENV !== 'production') {
+    if (!globalForDb.dbPool) {
+      globalForDb.dbPool = createPool();
+    }
+    return globalForDb.dbPool;
+  }
+
+  return createPool();
+};
+
+const createDbClient = (): DbClient => ({
+  workout: {
+    findMany: async ({ where, select }: WorkoutFindManyArgs): Promise<WorkoutRecord[]> => {
+      const columns = resolveSelect(select);
+      const whereQuery = buildWhereSql(where);
+      const sql = `SELECT ${columnSql(columns)} FROM "Workout" ${whereQuery.clause}`;
+      const result = await getPool().query(sql, whereQuery.values);
+      return result.rows as WorkoutRecord[];
+    },
+    findFirst: async ({ where, select }: WorkoutFindFirstArgs): Promise<WorkoutRecord | null> => {
+      const columns = resolveSelect(select);
+      const whereQuery = buildWhereSql(where);
+      const sql = `SELECT ${columnSql(columns)} FROM "Workout" ${whereQuery.clause} LIMIT 1`;
+      const result = await getPool().query(sql, whereQuery.values);
+      return (result.rows[0] as WorkoutRecord | undefined) ?? null;
+    },
+    count: async ({ where }: WorkoutCountArgs): Promise<number> => {
+      const whereQuery = buildWhereSql(where);
+      const sql = `SELECT COUNT(*)::int AS count FROM "Workout" ${whereQuery.clause}`;
+      const result = await getPool().query<{ count: number }>(sql, whereQuery.values);
+      return result.rows[0]?.count ?? 0;
+    },
+    upsert: async ({ where, create, update, select }: WorkoutUpsertArgs): Promise<WorkoutRecord> => {
+      const columns = resolveSelect(select);
+      const sql = `
+        INSERT INTO "Workout" ("id", "title", "timeCapSeconds", "equipment", "data", "isPublished")
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT ("id") DO UPDATE SET
+          "title" = $7,
+          "timeCapSeconds" = $8,
+          "equipment" = $9,
+          "data" = $10,
+          "isPublished" = $11
+        RETURNING ${columnSql(columns)}
+      `;
+
+      const values = [
+        where.id,
+        create.title,
+        create.timeCapSeconds,
+        create.equipment,
+        create.data,
+        create.isPublished,
+        update.title ?? create.title,
+        update.timeCapSeconds ?? create.timeCapSeconds,
+        update.equipment ?? create.equipment,
+        update.data ?? create.data,
+        update.isPublished ?? create.isPublished
+      ];
+
+      const result = await getPool().query(sql, values);
+      return result.rows[0] as WorkoutRecord;
+    }
+  }
+});
+
+const singletonDb = globalForDb.db ?? createDbClient();
 
 if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = db;
+  globalForDb.db = singletonDb;
 }
+
+export const db = singletonDb;


### PR DESCRIPTION
## Summary
Refactors runtime database access away from Prisma client initialization and onto `pg` + AWS RDS IAM signer so deployed API handlers can query Aurora without static `DATABASE_URL` at runtime.

## What changed
- Replaced `/src/lib/db.ts` Prisma client singleton with a SQL client abstraction backed by:
  - `pg` connection pool
  - `@aws-sdk/rds-signer` IAM token generation
  - `@vercel/functions/oidc` credentials provider
  - `attachDatabasePool` for Vercel lifecycle handling
- Preserved route call sites by keeping the existing `db.workout.findMany/findFirst/count/upsert` API.
- Removed Prisma-only types from workout route contracts and random route filter typing.
- Updated DB singleton test to validate the new DB client singleton behavior.
- Updated README runtime env guidance to reflect IAM-based runtime access.

## Validation
- `npm test` ✅
- `npm run build` ✅

## Notes
- `prisma/dev.db` is intentionally excluded.
- Prisma remains in use for migrations/seed workflows.
