### PR TITLE
[P0] Add API abuse protections and admin endpoint hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ Create a `.env` file in the repo root.
 - `ADMIN_API_KEY`:
   - Required by `POST /api/admin/workouts` via `x-admin-key` header.
   - Example: `ADMIN_API_KEY="replace-with-long-random-secret"`
+- `API_PUBLIC_RATE_LIMIT_PER_MINUTE`:
+  - Optional public API requests per IP+route per minute (default `60`).
+- `API_ADMIN_RATE_LIMIT_PER_MINUTE`:
+  - Optional admin API requests per IP per minute (default `12`).
+- `API_ADMIN_AUTH_FAILURE_THRESHOLD`:
+  - Optional failed admin auth attempts before lockout (default `5`).
+- `API_ADMIN_LOCKOUT_BASE_SECONDS`:
+  - Optional base lockout duration in seconds (default `30`), with exponential backoff.
+- `API_ADMIN_LOCKOUT_MAX_SECONDS`:
+  - Optional max lockout duration in seconds (default `900`).
+- `API_ADMIN_REQUEST_MAX_BYTES`:
+  - Optional max request body size for admin route (default `65536`).
+- `API_PUBLIC_REQUEST_TIMEOUT_MS`:
+  - Optional timeout for public route DB operations (default `1500`).
+- `API_ADMIN_REQUEST_TIMEOUT_MS`:
+  - Optional timeout for admin route DB operations (default `2500`).
+- `API_MAX_URL_LENGTH`:
+  - Optional max request URL length before `414` (default `2048`).
 
 Reference example:
 
@@ -86,6 +104,12 @@ Phase 2 validation evidence checklist is in `/Users/dmaia/development/repos/wod-
   - `error.code: string`
   - `error.message: string`
   - `error.details?: { path: string; message: string }[]`
+- Abuse protection responses:
+  - `429` for rate limits/lockouts (`Retry-After` header included)
+  - `403` for blocked suspicious bot/scanner patterns
+  - `414` for oversized URL requests
+  - `413` for oversized admin request bodies
+  - `503` when request timeout thresholds are exceeded
 
 ### `GET /api/workouts/random`
 - Query params:
@@ -124,4 +148,5 @@ Phase 2 validation evidence checklist is in `/Users/dmaia/development/repos/wod-
     - `id: string`
     - `isPublished: boolean`
   - `401` when `x-admin-key` is missing or invalid
+  - `429` when admin lockout/rate limit is triggered (includes `Retry-After`)
   - `400` when request body JSON is invalid or workout validation fails

--- a/src/app/api/workouts/[id]/route.ts
+++ b/src/app/api/workouts/[id]/route.ts
@@ -1,3 +1,9 @@
+import {
+  applyRateLimitHeaders,
+  enforcePublicApiProtections,
+  toTimeoutErrorResponse,
+  withApiTimeout
+} from '../../../../lib/api-abuse-protection.js';
 import { jsonError } from '../../../../lib/api-error.js';
 import { db } from '../../../../lib/db.js';
 
@@ -13,26 +19,42 @@ type RouteContext = {
 };
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: RouteContext
 ): Promise<Response> {
+  const protection = enforcePublicApiProtections(request);
+  if ('response' in protection) {
+    return protection.response;
+  }
+
   const { id } = await params;
-  const workout = await db.workout.findFirst({
-    where: {
-      id,
-      isPublished: true
-    },
-    select: workoutApiSelect
-  });
+  let workout;
+  try {
+    workout = await withApiTimeout(
+      db.workout.findFirst({
+        where: {
+          id,
+          isPublished: true
+        },
+        select: workoutApiSelect
+      }),
+      'public'
+    );
+  } catch {
+    return toTimeoutErrorResponse();
+  }
 
   if (!workout) {
-    return jsonError(404, 'NOT_FOUND', 'Workout not found');
+    const response = jsonError(404, 'NOT_FOUND', 'Workout not found');
+    return applyRateLimitHeaders(response, protection.rateLimitHeaders);
   }
 
   const response = toWorkoutResponse(workout);
   if (response === null) {
-    return jsonError(500, 'INTERNAL_ERROR', 'Stored workout payload is invalid');
+    const invalidResponse = jsonError(500, 'INTERNAL_ERROR', 'Stored workout payload is invalid');
+    return applyRateLimitHeaders(invalidResponse, protection.rateLimitHeaders);
   }
 
-  return Response.json(response, { status: 200 });
+  const okResponse = Response.json(response, { status: 200 });
+  return applyRateLimitHeaders(okResponse, protection.rateLimitHeaders);
 }

--- a/src/app/api/workouts/route.ts
+++ b/src/app/api/workouts/route.ts
@@ -1,12 +1,29 @@
+import {
+  applyRateLimitHeaders,
+  enforcePublicApiProtections,
+  toTimeoutErrorResponse,
+  withApiTimeout
+} from '../../../lib/api-abuse-protection.js';
 import { db } from '../../../lib/db.js';
 
 type WorkoutsScaffoldResponse = {
   count: number;
 };
 
-export async function GET(): Promise<Response> {
-  const count = await db.workout.count({});
-  const body: WorkoutsScaffoldResponse = { count };
+export async function GET(request: Request): Promise<Response> {
+  const protection = enforcePublicApiProtections(request);
+  if ('response' in protection) {
+    return protection.response;
+  }
 
-  return Response.json(body, { status: 200 });
+  let count: number;
+  try {
+    count = await withApiTimeout(db.workout.count({}), 'public');
+  } catch {
+    return toTimeoutErrorResponse();
+  }
+
+  const body: WorkoutsScaffoldResponse = { count };
+  const response = Response.json(body, { status: 200 });
+  return applyRateLimitHeaders(response, protection.rateLimitHeaders);
 }

--- a/src/lib/api-abuse-protection.ts
+++ b/src/lib/api-abuse-protection.ts
@@ -1,0 +1,442 @@
+import { jsonError } from './api-error.js';
+
+type RateLimitConfig = {
+  limit: number;
+  windowMs: number;
+};
+
+type RateLimitResult =
+  | {
+      blocked: false;
+      headers: Headers;
+    }
+  | {
+      blocked: true;
+      response: Response;
+    };
+
+type RateLimitState = {
+  windowStart: number;
+  count: number;
+};
+
+type AdminAuthState = {
+  failures: number;
+  lockoutUntilMs: number;
+};
+
+const rateLimitStore = new Map<string, RateLimitState>();
+const adminAuthStore = new Map<string, AdminAuthState>();
+
+const DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 60;
+const DEFAULT_ADMIN_RATE_LIMIT_PER_MINUTE = 12;
+const DEFAULT_ADMIN_AUTH_FAILURE_THRESHOLD = 5;
+const DEFAULT_ADMIN_LOCKOUT_BASE_SECONDS = 30;
+const DEFAULT_ADMIN_LOCKOUT_MAX_SECONDS = 900;
+const DEFAULT_ADMIN_REQUEST_MAX_BYTES = 64 * 1024;
+const DEFAULT_PUBLIC_REQUEST_TIMEOUT_MS = 1500;
+const DEFAULT_ADMIN_REQUEST_TIMEOUT_MS = 2500;
+const DEFAULT_MAX_URL_LENGTH = 2048;
+const ONE_MINUTE_MS = 60_000;
+
+const suspiciousUserAgentTokens = [
+  'sqlmap',
+  'nikto',
+  'masscan',
+  'nmap',
+  'acunetix',
+  'nessus',
+  'zgrab',
+  'gobuster',
+  'dirbuster',
+  'ffuf'
+];
+
+const suspiciousPathTokens = [
+  '../',
+  '..%2f',
+  '<script',
+  'union%20select',
+  'or%201=1',
+  '%00',
+  '/.env',
+  '/wp-admin',
+  '/phpmyadmin'
+];
+
+const parsePositiveInt = (rawValue: string | undefined, fallback: number): number => {
+  if (!rawValue) {
+    return fallback;
+  }
+
+  const value = Number(rawValue);
+  if (!Number.isInteger(value) || value <= 0) {
+    return fallback;
+  }
+
+  return value;
+};
+
+const getClientIp = (request: Request): string => {
+  const candidate =
+    request.headers.get('x-vercel-forwarded-for') ??
+    request.headers.get('x-forwarded-for') ??
+    request.headers.get('cf-connecting-ip') ??
+    request.headers.get('x-real-ip');
+
+  if (!candidate) {
+    return 'unknown';
+  }
+
+  return candidate
+    .split(',')[0]
+    .trim()
+    .slice(0, 128) || 'unknown';
+};
+
+const isSuspiciousRequest = (request: Request): boolean => {
+  const userAgent = (request.headers.get('user-agent') ?? '').toLowerCase();
+  const pathAndQuery = request.url.toLowerCase();
+
+  return (
+    suspiciousUserAgentTokens.some((token) => userAgent.includes(token)) ||
+    suspiciousPathTokens.some((token) => pathAndQuery.includes(token))
+  );
+};
+
+const validateUrlLength = (request: Request): Response | null => {
+  const maxUrlLength = parsePositiveInt(
+    process.env.API_MAX_URL_LENGTH,
+    DEFAULT_MAX_URL_LENGTH
+  );
+
+  if (request.url.length > maxUrlLength) {
+    return jsonError(414, 'URI_TOO_LONG', 'Request URL is too long');
+  }
+
+  return null;
+};
+
+const validateRequestBodySize = (
+  request: Request,
+  maxBytes: number
+): Response | null => {
+  const rawSize = request.headers.get('content-length');
+  if (!rawSize) {
+    return null;
+  }
+
+  const size = Number(rawSize);
+  if (!Number.isFinite(size) || size < 0) {
+    return jsonError(400, 'BAD_REQUEST', 'Invalid content-length header');
+  }
+
+  if (size > maxBytes) {
+    return jsonError(413, 'PAYLOAD_TOO_LARGE', 'Request payload exceeds maximum allowed size');
+  }
+
+  return null;
+};
+
+const buildRateLimitHeaders = (
+  config: RateLimitConfig,
+  state: RateLimitState,
+  nowMs: number
+): Headers => {
+  const resetSeconds = Math.max(
+    1,
+    Math.ceil((state.windowStart + config.windowMs - nowMs) / 1000)
+  );
+  const remaining = Math.max(config.limit - state.count, 0);
+  const headers = new Headers();
+  headers.set('X-RateLimit-Limit', String(config.limit));
+  headers.set('X-RateLimit-Remaining', String(remaining));
+  headers.set('X-RateLimit-Reset', String(resetSeconds));
+  return headers;
+};
+
+const applyRateLimit = (
+  key: string,
+  config: RateLimitConfig,
+  nowMs: number
+): RateLimitResult => {
+  const existing = rateLimitStore.get(key);
+  if (!existing || nowMs - existing.windowStart >= config.windowMs) {
+    const freshState: RateLimitState = {
+      windowStart: nowMs,
+      count: 1
+    };
+    rateLimitStore.set(key, freshState);
+    return { blocked: false, headers: buildRateLimitHeaders(config, freshState, nowMs) };
+  }
+
+  if (existing.count >= config.limit) {
+    const retrySeconds = Math.max(
+      1,
+      Math.ceil((existing.windowStart + config.windowMs - nowMs) / 1000)
+    );
+    const headers = buildRateLimitHeaders(config, existing, nowMs);
+    headers.set('Retry-After', String(retrySeconds));
+    return {
+      blocked: true,
+      response: jsonError(
+        429,
+        'RATE_LIMITED',
+        'Too many requests. Please retry later.',
+        undefined,
+        headers
+      )
+    };
+  }
+
+  existing.count += 1;
+  rateLimitStore.set(key, existing);
+  return { blocked: false, headers: buildRateLimitHeaders(config, existing, nowMs) };
+};
+
+const buildPublicRouteKey = (request: Request): string => {
+  const route = new URL(request.url).pathname;
+  return `public:${route}:${getClientIp(request)}`;
+};
+
+const buildAdminRouteKey = (request: Request): string => {
+  return `admin:${getClientIp(request)}`;
+};
+
+const getPublicRateConfig = (): RateLimitConfig => ({
+  limit: parsePositiveInt(
+    process.env.API_PUBLIC_RATE_LIMIT_PER_MINUTE,
+    DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE
+  ),
+  windowMs: ONE_MINUTE_MS
+});
+
+const getAdminRateConfig = (): RateLimitConfig => ({
+  limit: parsePositiveInt(
+    process.env.API_ADMIN_RATE_LIMIT_PER_MINUTE,
+    DEFAULT_ADMIN_RATE_LIMIT_PER_MINUTE
+  ),
+  windowMs: ONE_MINUTE_MS
+});
+
+const getAdminLockoutFailureThreshold = (): number =>
+  parsePositiveInt(
+    process.env.API_ADMIN_AUTH_FAILURE_THRESHOLD,
+    DEFAULT_ADMIN_AUTH_FAILURE_THRESHOLD
+  );
+
+const getAdminLockoutBaseSeconds = (): number =>
+  parsePositiveInt(
+    process.env.API_ADMIN_LOCKOUT_BASE_SECONDS,
+    DEFAULT_ADMIN_LOCKOUT_BASE_SECONDS
+  );
+
+const getAdminLockoutMaxSeconds = (): number =>
+  parsePositiveInt(
+    process.env.API_ADMIN_LOCKOUT_MAX_SECONDS,
+    DEFAULT_ADMIN_LOCKOUT_MAX_SECONDS
+  );
+
+const getPublicTimeoutMs = (): number =>
+  parsePositiveInt(
+    process.env.API_PUBLIC_REQUEST_TIMEOUT_MS,
+    DEFAULT_PUBLIC_REQUEST_TIMEOUT_MS
+  );
+
+const getAdminTimeoutMs = (): number =>
+  parsePositiveInt(
+    process.env.API_ADMIN_REQUEST_TIMEOUT_MS,
+    DEFAULT_ADMIN_REQUEST_TIMEOUT_MS
+  );
+
+const getAdminMaxBodyBytes = (): number =>
+  parsePositiveInt(
+    process.env.API_ADMIN_REQUEST_MAX_BYTES,
+    DEFAULT_ADMIN_REQUEST_MAX_BYTES
+  );
+
+const getAdminState = (key: string): AdminAuthState => {
+  return (
+    adminAuthStore.get(key) ?? {
+      failures: 0,
+      lockoutUntilMs: 0
+    }
+  );
+};
+
+const setAdminState = (key: string, state: AdminAuthState): void => {
+  adminAuthStore.set(key, state);
+};
+
+export const applyRateLimitHeaders = (
+  response: Response,
+  rateLimitHeaders: Headers
+): Response => {
+  const headers = new Headers(response.headers);
+  rateLimitHeaders.forEach((value, name) => {
+    headers.set(name, value);
+  });
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
+};
+
+export const enforcePublicApiProtections = (
+  request: Request
+): { rateLimitHeaders: Headers } | { response: Response } => {
+  const longUrlResponse = validateUrlLength(request);
+  if (longUrlResponse) {
+    return { response: longUrlResponse };
+  }
+
+  if (isSuspiciousRequest(request)) {
+    return {
+      response: jsonError(403, 'BOT_BLOCKED', 'Request blocked by abuse protections')
+    };
+  }
+
+  const nowMs = Date.now();
+  const rateLimitResult = applyRateLimit(
+    buildPublicRouteKey(request),
+    getPublicRateConfig(),
+    nowMs
+  );
+
+  if (rateLimitResult.blocked) {
+    return { response: rateLimitResult.response };
+  }
+
+  return { rateLimitHeaders: rateLimitResult.headers };
+};
+
+export const enforceAdminRoutePreAuth = (
+  request: Request
+): { key: string; rateLimitHeaders: Headers } | { response: Response } => {
+  const longUrlResponse = validateUrlLength(request);
+  if (longUrlResponse) {
+    return { response: longUrlResponse };
+  }
+
+  if (isSuspiciousRequest(request)) {
+    return {
+      response: jsonError(403, 'BOT_BLOCKED', 'Request blocked by abuse protections')
+    };
+  }
+
+  const largeBodyResponse = validateRequestBodySize(request, getAdminMaxBodyBytes());
+  if (largeBodyResponse) {
+    return { response: largeBodyResponse };
+  }
+
+  const key = buildAdminRouteKey(request);
+  const nowMs = Date.now();
+
+  const state = getAdminState(key);
+  if (state.lockoutUntilMs > nowMs) {
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((state.lockoutUntilMs - nowMs) / 1000)
+    );
+    const headers = new Headers();
+    headers.set('Retry-After', String(retryAfterSeconds));
+    return {
+      response: jsonError(
+        429,
+        'ADMIN_LOCKED',
+        'Too many invalid admin authentication attempts. Please retry later.',
+        undefined,
+        headers
+      )
+    };
+  }
+
+  const rateLimitResult = applyRateLimit(key, getAdminRateConfig(), nowMs);
+  if (rateLimitResult.blocked) {
+    return { response: rateLimitResult.response };
+  }
+
+  return { key, rateLimitHeaders: rateLimitResult.headers };
+};
+
+export const registerAdminAuthFailure = (
+  key: string
+): { response: Response } => {
+  const nowMs = Date.now();
+  const state = getAdminState(key);
+  const failures = state.failures + 1;
+  const threshold = getAdminLockoutFailureThreshold();
+  const failuresPastThreshold = Math.max(failures - threshold, 0);
+
+  let lockoutSeconds = 0;
+  if (failures >= threshold) {
+    lockoutSeconds = Math.min(
+      getAdminLockoutMaxSeconds(),
+      getAdminLockoutBaseSeconds() * 2 ** failuresPastThreshold
+    );
+  }
+
+  const nextState: AdminAuthState = {
+    failures,
+    lockoutUntilMs: lockoutSeconds > 0 ? nowMs + lockoutSeconds * 1000 : 0
+  };
+  setAdminState(key, nextState);
+
+  if (lockoutSeconds > 0) {
+    const headers = new Headers();
+    headers.set('Retry-After', String(lockoutSeconds));
+    return {
+      response: jsonError(
+        429,
+        'ADMIN_LOCKED',
+        'Too many invalid admin authentication attempts. Please retry later.',
+        undefined,
+        headers
+      )
+    };
+  }
+
+  return {
+    response: jsonError(401, 'UNAUTHORIZED', 'Missing or invalid admin API key')
+  };
+};
+
+export const clearAdminAuthFailureState = (key: string): void => {
+  setAdminState(key, {
+    failures: 0,
+    lockoutUntilMs: 0
+  });
+};
+
+export const withApiTimeout = async <T>(
+  task: Promise<T>,
+  scope: 'public' | 'admin'
+): Promise<T> => {
+  const timeoutMs = scope === 'admin' ? getAdminTimeoutMs() : getPublicTimeoutMs();
+  let timer: NodeJS.Timeout | null = null;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error('API_REQUEST_TIMEOUT'));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([task, timeoutPromise]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+};
+
+export const toTimeoutErrorResponse = (): Response => {
+  return jsonError(503, 'REQUEST_TIMEOUT', 'Request timed out. Please retry.');
+};
+
+export const resetApiAbuseProtectionStateForTests = (): void => {
+  rateLimitStore.clear();
+  adminAuthStore.clear();
+};

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -15,7 +15,8 @@ export const jsonError = (
   status: number,
   code: string,
   message: string,
-  details?: ApiErrorDetail[]
+  details?: ApiErrorDetail[],
+  headers?: HeadersInit
 ): Response => {
   const body: ApiError = {
     error: {
@@ -25,5 +26,5 @@ export const jsonError = (
     }
   };
 
-  return Response.json(body, { status });
+  return Response.json(body, { status, headers });
 };

--- a/tests/api/workout-by-id-route.test.ts
+++ b/tests/api/workout-by-id-route.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resetApiAbuseProtectionStateForTests } from '../../src/lib/api-abuse-protection.js';
 
 const { findFirst } = vi.hoisted(() => ({
   findFirst: vi.fn()
@@ -16,6 +17,7 @@ import { GET } from '../../src/app/api/workouts/[id]/route.js';
 
 afterEach(() => {
   findFirst.mockReset();
+  resetApiAbuseProtectionStateForTests();
 });
 
 describe('GET /api/workouts/[id]', () => {

--- a/tests/api/workouts-route-scaffold.test.ts
+++ b/tests/api/workouts-route-scaffold.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resetApiAbuseProtectionStateForTests } from '../../src/lib/api-abuse-protection.js';
 
 const { count } = vi.hoisted(() => ({
   count: vi.fn().mockResolvedValue(3)
@@ -15,11 +16,41 @@ vi.mock('../../src/lib/db.js', () => ({
 import { GET } from '../../src/app/api/workouts/route.js';
 
 describe('GET /api/workouts scaffold', () => {
+  const originalPublicLimit = process.env.API_PUBLIC_RATE_LIMIT_PER_MINUTE;
+
+  afterEach(() => {
+    if (originalPublicLimit === undefined) {
+      delete process.env.API_PUBLIC_RATE_LIMIT_PER_MINUTE;
+    } else {
+      process.env.API_PUBLIC_RATE_LIMIT_PER_MINUTE = originalPublicLimit;
+    }
+
+    resetApiAbuseProtectionStateForTests();
+    count.mockClear();
+  });
+
   it('uses db singleton and returns count payload', async () => {
-    const response = await GET();
+    const response = await GET(new Request('https://example.com/api/workouts'));
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ count: 3 });
     expect(count).toHaveBeenCalledWith({});
+  });
+
+  it('returns 429 with retry-after when limit is exceeded', async () => {
+    process.env.API_PUBLIC_RATE_LIMIT_PER_MINUTE = '1';
+
+    const first = await GET(new Request('https://example.com/api/workouts'));
+    const second = await GET(new Request('https://example.com/api/workouts'));
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(second.headers.get('retry-after')).toBeTruthy();
+    expect(await second.json()).toEqual({
+      error: {
+        code: 'RATE_LIMITED',
+        message: 'Too many requests. Please retry later.'
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add centralized API abuse protection middleware for rate limiting, suspicious bot filtering, request-size guards, and timeout handling
- enforce public per-IP/per-route rate limiting on all public workout API endpoints with 429 + Retry-After semantics
- harden admin ingestion endpoint with stricter per-IP limits and auth-failure lockout/backoff behavior
- preserve API contract and attach rate-limit headers on success/error responses
- add tests for public rate limiting, suspicious UA blocking, and admin lockout behavior; update docs for new env controls

## Testing
- npm test

Closes #51