### PR TITLE
[P0] Add production security headers and policy checks

### DIFF
--- a/.github/workflows/security-headers.yml
+++ b/.github/workflows/security-headers.yml
@@ -1,0 +1,52 @@
+name: Security Headers
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  verify-security-headers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Verify security headers
+        run: |
+          set -euo pipefail
+          npm run start -- --hostname 127.0.0.1 --port 3100 > /tmp/next-security-headers.log 2>&1 &
+          NEXT_PID=$!
+          cleanup() {
+            kill "$NEXT_PID" || true
+          }
+          trap cleanup EXIT
+
+          READY=0
+          for i in $(seq 1 60); do
+            if curl -sSf http://127.0.0.1:3100/ > /dev/null; then
+              READY=1
+              break
+            fi
+            sleep 1
+          done
+          if [ "$READY" -ne 1 ]; then
+            cat /tmp/next-security-headers.log
+            exit 1
+          fi
+
+          SECURITY_CHECK_BASE_URL=http://127.0.0.1:3100 npm run check:security-headers

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Run these after deployment (or locally with `npm run dev`).
 Use the V1 release runbook in `/Users/dmaia/development/repos/wod-now/docs/v1-deploy-checklist.md`.
 Provider selection decision for Phase 2 is documented in `/Users/dmaia/development/repos/wod-now/docs/phase-2-postgres-provider-decision.md`.
 Phase 2 validation evidence checklist is in `/Users/dmaia/development/repos/wod-now/docs/phase-2-managed-postgres-validation.md`.
+Security header policy and CSP exceptions are documented in `/Users/dmaia/development/repos/wod-now/docs/security-headers.md`.
 
 ## API Contracts
 ### Error response contract (all endpoints)

--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -1,0 +1,49 @@
+# Security Headers Policy
+
+This project enforces baseline browser security headers on all routes (`/:path*`), including app pages and API responses.
+
+## Required headers
+- `Content-Security-Policy`
+- `Strict-Transport-Security`
+- `X-Content-Type-Options`
+- `Referrer-Policy`
+- `X-Frame-Options`
+- `Permissions-Policy`
+
+`x-powered-by` is disabled.
+
+## CSP directives and current exceptions
+Current CSP:
+- `default-src 'self'`
+- `base-uri 'self'`
+- `form-action 'self'`
+- `frame-ancestors 'none'`
+- `object-src 'none'`
+- `script-src 'self' 'unsafe-inline'`
+- `style-src 'self' 'unsafe-inline'`
+- `img-src 'self' data: blob:`
+- `font-src 'self' data:`
+- `connect-src 'self'`
+- `upgrade-insecure-requests`
+
+Documented exceptions:
+- `script-src 'unsafe-inline'`: required for current Next.js runtime inline scripts.
+- `style-src 'unsafe-inline'`: required for framework-injected inline styles.
+- `img-src data: blob:` and `font-src data:`: support local data/blob assets used by the app/runtime.
+
+No cookies are issued by this app today; if cookies are introduced later, they must use `Secure`, `HttpOnly`, and `SameSite` defaults unless there is a documented exception.
+
+## Verification
+Run the checker against a running app server:
+
+```bash
+npm run check:security-headers
+```
+
+Or with a custom base URL:
+
+```bash
+SECURITY_CHECK_BASE_URL=http://127.0.0.1:3100 npm run check:security-headers
+```
+
+CI runs this check via `.github/workflows/security-headers.yml`.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,57 @@
 import type { NextConfig } from 'next';
 
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "connect-src 'self'",
+  'upgrade-insecure-requests'
+].join('; ');
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: contentSecurityPolicy
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload'
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff'
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin'
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY'
+  },
+  {
+    key: 'Permissions-Policy',
+    value:
+      'accelerometer=(), autoplay=(), camera=(), geolocation=(), gyroscope=(), microphone=(), payment=(), usb=()'
+  }
+];
+
 const nextConfig: NextConfig = {
+  poweredByHeader: false,
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders
+      }
+    ];
+  },
   webpack(config) {
     config.resolve.extensionAlias = {
       ...(config.resolve.extensionAlias ?? {}),

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "db:migrate:status": "prisma migrate status",
     "db:migrate:deploy:iam": "node scripts/prisma-with-rds-iam.mjs prisma migrate deploy",
     "db:migrate:status:iam": "node scripts/prisma-with-rds-iam.mjs prisma migrate status",
+    "check:security-headers": "node scripts/check-security-headers.mjs",
     "typecheck": "tsc --noEmit",
     "test": "npm run prisma:generate && vitest run && npm run typecheck",
     "seed": "node --import=tsx prisma/seed.ts",

--- a/scripts/check-security-headers.mjs
+++ b/scripts/check-security-headers.mjs
@@ -1,0 +1,70 @@
+const baseUrl = process.env.SECURITY_CHECK_BASE_URL ?? 'http://127.0.0.1:3000';
+const routes = ['/', '/api/workouts/random'];
+
+const requiredHeaders = {
+  'content-security-policy': (value) =>
+    hasAll(value, [
+      "default-src 'self'",
+      "frame-ancestors 'none'",
+      "object-src 'none'",
+      "script-src 'self' 'unsafe-inline'",
+      "connect-src 'self'"
+    ]),
+  'strict-transport-security': (value) => hasAll(value, ['max-age=63072000', 'includeSubDomains']),
+  'x-content-type-options': (value) => value.toLowerCase() === 'nosniff',
+  'referrer-policy': (value) => value.toLowerCase() === 'strict-origin-when-cross-origin',
+  'x-frame-options': (value) => value.toUpperCase() === 'DENY',
+  'permissions-policy': (value) => hasAll(value, ['camera=()', 'microphone=()', 'geolocation=()'])
+};
+
+function hasAll(value, expectedParts) {
+  const normalized = value.toLowerCase();
+  return expectedParts.every((part) => normalized.includes(part.toLowerCase()));
+}
+
+async function checkRoute(route) {
+  const response = await fetch(`${baseUrl}${route}`);
+  const missing = [];
+  const invalid = [];
+
+  for (const [headerName, isValid] of Object.entries(requiredHeaders)) {
+    const value = response.headers.get(headerName);
+    if (!value) {
+      missing.push(headerName);
+      continue;
+    }
+
+    if (!isValid(value)) {
+      invalid.push(`${headerName}: ${value}`);
+    }
+  }
+
+  return {
+    route,
+    status: response.status,
+    missing,
+    invalid
+  };
+}
+
+async function main() {
+  const results = await Promise.all(routes.map((route) => checkRoute(route)));
+  const failures = results.filter((result) => result.missing.length > 0 || result.invalid.length > 0);
+
+  for (const result of results) {
+    console.log(`[security-headers] ${result.route} -> status ${result.status}`);
+    if (result.missing.length > 0) {
+      console.error(`  missing: ${result.missing.join(', ')}`);
+    }
+    if (result.invalid.length > 0) {
+      console.error(`  invalid: ${result.invalid.join(' | ')}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    process.exitCode = 1;
+    throw new Error('Security header checks failed');
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add global production security headers (CSP, HSTS, X-Content-Type-Options, Referrer-Policy, X-Frame-Options, Permissions-Policy) in Next config
- disable x-powered-by header
- add security header verification script for / and /api/workouts/random
- add CI workflow to build app, start server, and run security header checks
- document CSP directives, current exceptions, and verification steps

## Validation
- npm run build
- npm run typecheck

## Notes
- Live header check cannot run in this sandbox due to local port bind restrictions (EPERM); it runs in CI workflow.

Closes #49