### PR TITLE
Add privacy and terms pages with global footer links

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,12 @@ body {
   color: var(--text);
 }
 
+.site-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 h1,
 h2,
 h3,
@@ -46,6 +52,18 @@ a {
   padding: 2.4rem 1rem 3rem;
   display: grid;
   gap: 1rem;
+  flex: 1;
+}
+
+.site-footer {
+  width: min(1080px, 100%);
+  margin: 0 auto;
+  padding: 0 1rem 2.4rem;
+}
+
+.site-footer p {
+  margin: 0;
+  font-size: 0.92rem;
 }
 
 .controls,
@@ -252,6 +270,30 @@ button:disabled {
 
 .link-back {
   font-weight: 600;
+}
+
+.legal {
+  width: min(860px, 100%);
+  margin: 0 auto;
+  padding: 2.4rem 1rem 3rem;
+}
+
+.legal h1 {
+  margin-bottom: 0.8rem;
+}
+
+.legal h2 {
+  margin: 1.6rem 0 0.55rem;
+}
+
+.legal p,
+.legal li {
+  line-height: 1.6;
+}
+
+.legal ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1.2rem;
 }
 
 code {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,7 +55,16 @@ export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en">
       <body>
-        {children}
+        <div className="site-shell">
+          {children}
+          <footer className="site-footer">
+            <p className="muted">
+              <a href="/privacy-policy">Privacy Policy</a>
+              {' · '}
+              <a href="/terms-of-use">Terms of Use</a>
+            </p>
+          </footer>
+        </div>
         <AnalyticsScript />
       </body>
     </html>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description: 'How WOD Now handles operational data, cookies, and usage information.',
+  alternates: {
+    canonical: '/privacy-policy'
+  }
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <main className="legal">
+      <h1>Privacy Policy</h1>
+      <p className="muted">Last updated: February 19, 2026</p>
+
+      <p>
+        WOD Now provides a random workout generator and related API endpoints. This policy explains
+        what information we process to run the service.
+      </p>
+
+      <h2>Information We Process</h2>
+      <ul>
+        <li>Request metadata such as IP address and user agent for abuse protection and rate limiting.</li>
+        <li>Request URLs and headers required to deliver the requested page or API response.</li>
+      </ul>
+
+      <h2>Cookies and Analytics</h2>
+      <p>
+        WOD Now does not use advertising cookies, analytics cookies, or third-party tracking scripts
+        at this time.
+      </p>
+
+      <h2>How Data Is Used</h2>
+      <ul>
+        <li>To serve pages and API responses.</li>
+        <li>To apply security controls such as bot blocking, rate limits, and temporary lockouts.</li>
+      </ul>
+
+      <h2>Data Sharing</h2>
+      <p>
+        We do not sell personal information. Data is processed by our hosting and infrastructure
+        providers only as needed to operate the service.
+      </p>
+
+      <h2>Changes to This Policy</h2>
+      <p>
+        We may update this policy as the product evolves. Updates will be posted on this page with
+        a revised date.
+      </p>
+    </main>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -13,6 +13,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${siteUrl}/`,
       changeFrequency: 'daily',
       priority: 1
+    },
+    {
+      url: `${siteUrl}/privacy-policy`,
+      changeFrequency: 'monthly',
+      priority: 0.3
+    },
+    {
+      url: `${siteUrl}/terms-of-use`,
+      changeFrequency: 'monthly',
+      priority: 0.3
     }
   ];
 

--- a/src/app/terms-of-use/page.tsx
+++ b/src/app/terms-of-use/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Terms of Use',
+  description: 'Terms governing use of the WOD Now website and API.',
+  alternates: {
+    canonical: '/terms-of-use'
+  }
+};
+
+export default function TermsOfUsePage() {
+  return (
+    <main className="legal">
+      <h1>Terms of Use</h1>
+      <p className="muted">Last updated: February 19, 2026</p>
+
+      <p>
+        By accessing WOD Now, you agree to use the website and API in accordance with these terms.
+      </p>
+
+      <h2>Permitted Use</h2>
+      <ul>
+        <li>Use the service for lawful purposes only.</li>
+        <li>Avoid attempts to disrupt, overload, or abuse the platform.</li>
+        <li>Comply with published request limits and security controls.</li>
+      </ul>
+
+      <h2>Service Availability</h2>
+      <p>
+        The service is provided on an as-is, as-available basis. We may change or discontinue
+        features at any time.
+      </p>
+
+      <h2>Content and Liability</h2>
+      <p>
+        Workout content is provided for general informational purposes and is not medical advice.
+        You are responsible for evaluating whether a workout is appropriate for your condition and
+        training level.
+      </p>
+
+      <h2>Prohibited Actions</h2>
+      <ul>
+        <li>Attempting unauthorized access to infrastructure or administrative endpoints.</li>
+        <li>Automated scraping or probing intended to bypass protections.</li>
+        <li>Use that violates applicable law.</li>
+      </ul>
+
+      <h2>Updates to Terms</h2>
+      <p>
+        We may revise these terms by posting an updated version on this page. Continued use after
+        changes means you accept the updated terms.
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add /privacy-policy and /terms-of-use pages with launch-focused legal copy
- add global footer links in root layout so both pages are accessible across the app
- include both legal routes in sitemap output

## Validation
- npm test

Closes #53